### PR TITLE
Suggesting people to stop using Karabiner in case of problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Utility for 'ThinkPad Compact Bluetooth Keyboard with TrackPoint' (0B47189) for 
   - changes middle button mode
 
 It needs to be run with `sudo`.
+Make sure you don't have Karabiner app launched on your machine (otherwise tpkb won't work)

--- a/tpkb/tp.cpp
+++ b/tpkb/tp.cpp
@@ -16,7 +16,9 @@ int main()
     hid_device *dev = hid_open(vendor_id, product_id, 0);
     
     if (dev == 0) {
-        printf("TP Keyboard not found. Have you run it with 'sudo'?\n");
+        printf("TP Keyboard not found. Possible solutions:\n"
+               " * Have you run tpkb with 'sudo'?\n"
+               " * Make sure you don't have keyboard customizers running (for example Karabiner)\n");
         return 0;
     }
     


### PR DESCRIPTION
Thanks for this great tool! I'm big fan of TP keyboard and can use it for coding with help of your util.
I found that usage of Karabiner (https://pqrs.org/osx/karabiner/) prevents tpkb from working. It may take some time for people to realize the cause of issue. This pull request adds some friendly suggestions about karabiner.
I hope it will help many people.

I tested this change, output looks like this:
```
$ ./tpkb
TP Keyboard not found. Possible solutions:
 * Have you run tpkb with 'sudo'?
 * Make sure you don't have keyboard customizers running (for example Karabiner)```

Feel free to request changes.